### PR TITLE
Feature/jobs router geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ The POST `jobs/new` Endpoint needs the following JSON information:
 
 ```#! json
 {
-  "washAddress": "42 Wallaby Way Sydney", --Required  --String  --Address of job
+  "washAddress": "42 Wallaby Way Sydney", --Required  --String  --Address of job(used to calculate jobLocationLat and jobLocationLon variables if none are provided with the request. Only works for US addresses.)
   "scheduled": true,                                  --Boolean --Defaults to true
   "completed": false,                                 --Boolean --Defaults to false
   "paid": false,                                      --Boolean --Defaults to false
@@ -647,8 +647,8 @@ The POST `jobs/new` Endpoint returns the following JSON information:
   "creationDate": "time stamp",             --String  --Time stamp of job creation
   "address": "123 First St",                --String  --Address of Job
   "address2": "APT 2",                      --String  --Adress second line
-  "jobLocationLat": null,                   --Float   --Latitude of job location
-  "jobLocationLon": null,                   --Float   --Longitude of job location
+  "jobLocationLat": "38.132456",            --Float   --Latitude of job location(calculated by washAddress unless provided)
+  "jobLocationLon": "-121.123654",          --Float   --Longitude of job location(calculated by washAddress unless provided)
   "city": "tampa",                          --String  --City of job location
   "state": "FL",                            --String  --State of job location
   "zip": "60184",                           --String  --Zip of job location

--- a/jobs/jobs-router.js
+++ b/jobs/jobs-router.js
@@ -159,10 +159,6 @@ async function addJobLatLon(req, res, next) {
       const getLocation = await axios.get(
         `https://api.mapbox.com/geocoding/v5/mapbox.places/${req.body.washAddress}.json?country=${country}&limit=1&autocomplete=true&access_token=${TOKEN}`
       );
-      console.log(
-        "Jobs Router - POST NEW JOB ",
-        getLocation.data.features[0].geometry
-      );
       req.jobLat = getLocation.data.features[0].geometry.coordinates[1];
       req.jobLon = getLocation.data.features[0].geometry.coordinates[0];
       next();

--- a/jobs/jobs-router.js
+++ b/jobs/jobs-router.js
@@ -1,3 +1,5 @@
+const axios = require("axios");
+
 const jobsRouter = require("express").Router();
 const {
   addNewJob,
@@ -14,6 +16,8 @@ const {
 jobsRouter.post("/new", async (req, res) => {
   const date = new Date();
   const creationDate = date;
+  const TOKEN =
+    "pk.eyJ1IjoicXVhbjAwNSIsImEiOiJjazN0a2N3a2YwM3ViM2twdzhkbGphMTZzIn0.OepqB_mymhr1YLSYwNmRSg"; // Set your mapbox token here
   const {
     clientId,
     washAddress,
@@ -29,14 +33,32 @@ jobsRouter.post("/new", async (req, res) => {
     jobType,
     timeRequested,
   } = req.body;
+  let lat, lon;
+  if (!jobLocationLat || !jobLocationLon) {
+    const country = "us";
+    try {
+      const getLocation = await axios.get(
+        `https://api.mapbox.com/geocoding/v5/mapbox.places/${address}.json?country=${country}&limit=1&autocomplete=true&access_token=${TOKEN}`
+      );
+      console.log(
+        "Jobs Router - POST NEW JOB ",
+        getLocation.data.features[0].geometry
+      );
+      lat = getLocation.data.features[0].geometry.coordinates[1];
+      lon = getLocation.data.features[0].geometry.coordinates[0];
+      console.log("lat, lon", lat, lon);
+    } catch (err) {
+      res.status(500).json(err.message);
+    }
+  }
   const newJob = {
     clientId,
     washAddress,
     carId,
     address,
     address2,
-    jobLocationLat,
-    jobLocationLon,
+    jobLocationLat: lat,
+    jobLocationLon: lon,
     city,
     state,
     zip,

--- a/jobs/jobs-router.js
+++ b/jobs/jobs-router.js
@@ -33,7 +33,8 @@ jobsRouter.post("/new", async (req, res) => {
     jobType,
     timeRequested,
   } = req.body;
-  let lat, lon;
+  let lat = 0;
+  let lon = 0;
   if (!jobLocationLat || !jobLocationLon) {
     const country = "us";
     try {

--- a/jobs/jobs-router.js
+++ b/jobs/jobs-router.js
@@ -151,6 +151,10 @@ function validateJobId(req, res, next) {
 }
 // adds a job latitude and longitude if none are provided based on the washAddress
 async function addJobLatLon(req, res, next) {
+  if (!req.body.washAddress || req.body.washAddress.length < 5)
+    return res
+      .status(500)
+      .json({ message: "Please provide a valid washAddress" });
   if (!req.body.jobLocationLat || !req.body.jobLocationLon) {
     const TOKEN =
       "pk.eyJ1IjoicXVhbjAwNSIsImEiOiJjazN0a2N3a2YwM3ViM2twdzhkbGphMTZzIn0.OepqB_mymhr1YLSYwNmRSg"; // Set your mapbox token here


### PR DESCRIPTION
# Description

-when creating a new job and providing a washAddress the backend will calculate the latitude and longitude of the wash location and store it on the jobs table and return it in the response.
-if a job lat and long are already provided with the create new job post request the provided values will be stored and returned.

Fixes # (issue)

-Calculates job wash address latitude and longitude and saves them on the backend jobs table.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Change Status

- [ ] Complete, tested, ready to review and merge
- [x] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

- [x] Test A - tested locally with postman and working as it should


# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
